### PR TITLE
Export metrics

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,20 @@
+Monitoring Benchmark with Prometheus and Grafana
+===
+
+This directory has an example on how to deploy Prometheus and Grafana to monitor the benchmark instances
+
+# Requirements
+
+* Docker
+* Docker-Compose
+* The benchmark instance must be accessible and started with option `-metrics-port <port>`. The `<port>` must be open in the firewall too.
+
+# Procedure
+
+* Update the file `infinispan.yaml` wit the IP and ports of all the benchmark instances. 
+Under the `static_configs` section, set the `targets` list with all the IPs and port.
+* Optionally, edit the `docker-compose.yaml` to use a different username and password for Grafana.
+Those are set under `GF_SECURITY_ADMIN_USER` and `GF_SECURITY_ADMIN_PASSWORD` environment variables.
+* Start the containers with `docker-compose up -d`.
+* Grafana will be available at `http://127.0.0.1:3000/`.
+It includes a simple dashboard with the CPU usage, reads and writes heat map and 99th percentile data.

--- a/monitoring/docker-compose.yaml
+++ b/monitoring/docker-compose.yaml
@@ -1,0 +1,37 @@
+networks:
+  monitoring:
+    driver: bridge
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    hostname: prometheus
+    container_name: prometheus
+    volumes:
+      - ./infinispan.yaml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    ports:
+      - 9090:9090
+    networks:
+      - monitoring
+  grafana:
+    image: grafana/grafana:latest
+    hostname: grafana
+    container_name: grafana
+    environment:
+      GF_INSTALL_PLUGINS: 'grafana-clock-panel,grafana-simple-json-datasource'
+      GF_SECURITY_ADMIN_USER: 'grafana'
+      GF_SECURITY_ADMIN_PASSWORD: 'grafana'
+      GF_USERS_ALLOW_SIGN_UP: false
+    volumes:
+      - ./grafana_provisioning:/etc/grafana/provisioning/
+    ports:
+      - 3000:3000
+    depends_on:
+      - prometheus
+    networks:
+      - monitoring

--- a/monitoring/grafana_provisioning/dashboards/benchmark.json
+++ b/monitoring/grafana_provisioning/dashboards/benchmark.json
@@ -1,0 +1,480 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 5,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 13,
+      "panels": [],
+      "repeat": "instance",
+      "title": "$instance stats",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "mean",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "base_cpu_processCpuLoad{instance=~\"$instance\"}",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "CPU Usage",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "$instance - CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true,
+          "showLegend": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "decimals": 3,
+          "reverse": false
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (le) (idelta(requests_seconds_bucket{instance=~\"$instance\", operation=\"GET\"} [2m]))",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "$instance - Read Response Time",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 14,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true,
+          "showLegend": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "decimals": 3,
+          "reverse": false
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (le) (idelta(requests_seconds_bucket{instance=~\"$instance\", operation=\"PUT\"} [2m]))",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "$instance - Write Response Time",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (irate(requests_seconds_bucket{instance=~\"$instance\", operation=\"GET\"}[2m])))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "GET",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (irate(requests_seconds_bucket{instance=~\"$instance\", operation=\"PUT\"}[2m])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "legendFormat": "PUT",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "$instance - 99 quantile millis",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "vendor_cache_container_health_number_of_cpus",
+        "includeAll": true,
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "qryType": 4,
+          "query": "vendor_cache_container_health_number_of_cpus",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/instance=\"([^\"]*)\"/",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Benchmark",
+  "uid": "R3kK_894z",
+  "version": 3
+}

--- a/monitoring/grafana_provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana_provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'Default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/monitoring/grafana_provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana_provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    access: proxy
+    editable: true

--- a/monitoring/infinispan.yaml
+++ b/monitoring/infinispan.yaml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: "codelab-monitor"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: "perf-test"
+    static_configs:
+      - targets: [ "172.17.0.1:8080","172.17.0.1:8081" ]

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,14 @@
     </scm>
 
     <properties>
+        <!-- ISPN 16 -->
         <!--<version.infinispan>16.0.0.Dev03</version.infinispan>-->
+        <!--<version.micrometer>1.15.2</version.micrometer>-->
+
+        <!-- ISPN 15 -->
         <version.infinispan>15.0.18.Final</version.infinispan>
+        <version.micrometer>1.12.13</version.micrometer>
+
         <version.jgroups>5.5.0.Final-SNAPSHOT</version.jgroups>
         <version.hazelcast>5.5.0</version.hazelcast>
         <version.hdrhistogram>2.2.2</version.hdrhistogram>
@@ -237,6 +243,18 @@
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman</artifactId>
             <version>4.0.25</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${version.micrometer}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${version.micrometer}</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/cache/CacheFactory.java
+++ b/src/main/java/org/cache/CacheFactory.java
@@ -1,5 +1,7 @@
 package org.cache;
 
+import java.util.function.LongConsumer;
+
 /**
  * Creates instances of {@link Cache}
  * @author Bela Ban
@@ -9,10 +11,8 @@ public interface CacheFactory<K,V> {
 
     /**
      * Called after creation to configure the cache factory
-     * @param config
-     * @throws Exception
      */
-    void init(String config) throws Exception;
+    void init(String config, boolean metricsEnabled, int metricsPort) throws Exception;
 
     /**
      * Called to destroy the cache manager and de-allocate resources created by it
@@ -26,4 +26,8 @@ public interface CacheFactory<K,V> {
      * @return a newly created and configured cache
      */
     Cache<K,V> create(String cache_name, String name);
+
+    default LongConsumer metricForOperation(String operation) {
+        return value -> {};
+    }
 }

--- a/src/main/java/org/cache/impl/DummyCacheFactory.java
+++ b/src/main/java/org/cache/impl/DummyCacheFactory.java
@@ -12,7 +12,7 @@ public class DummyCacheFactory<K,V> implements CacheFactory<K,V> {
     protected String     config;
     protected DummyCache cache;
 
-    public void init(String config) throws Exception {
+    public void init(String config, boolean metricsEnabled, int metricsPort) throws Exception {
         this.config=config;
     }
 

--- a/src/main/java/org/cache/impl/HazelcastCacheFactory.java
+++ b/src/main/java/org/cache/impl/HazelcastCacheFactory.java
@@ -20,7 +20,7 @@ public class HazelcastCacheFactory<K,V> implements CacheFactory<K,V> {
     public HazelcastCacheFactory() {
     }
 
-    public void init(String config) throws Exception {
+    public void init(String config, boolean metricsEnabled, int metricsPort) throws Exception {
         com.hazelcast.config.Config conf=new ClasspathXmlConfig(config);
         hc=Hazelcast.newHazelcastInstance(conf);
     }

--- a/src/main/java/org/cache/impl/InfinispanCacheFactory.java
+++ b/src/main/java/org/cache/impl/InfinispanCacheFactory.java
@@ -1,13 +1,33 @@
 package org.cache.impl;
 
+import com.sun.net.httpserver.HttpServer;
+import io.micrometer.core.instrument.Timer;
 import org.cache.Cache;
 import org.cache.CacheFactory;
+import org.infinispan.commons.configuration.io.ConfigurationResourceResolvers;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.util.FileLookupFactory;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.configuration.parsing.ParserRegistry;
+import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.metrics.Constants;
+import org.infinispan.metrics.impl.MetricsRegistry;
+import org.infinispan.metrics.impl.MetricsRegistryImpl;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
 import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
+import org.jgroups.util.ThreadCreator;
 import org.jgroups.util.Util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongConsumer;
 
 /**
  * @author Bela Ban
@@ -17,24 +37,52 @@ import org.jgroups.util.Util;
 @Listener
 public class InfinispanCacheFactory<K,V> implements CacheFactory<K,V> {
     protected EmbeddedCacheManager mgr;
+    private Thread metricsServerThread;
 
     /** Empty constructor needed for an instance to be created via reflection */
     public InfinispanCacheFactory() {
     }
 
-    public void init(String config) throws Exception {
-        mgr=new DefaultCacheManager(config);
+    public void init(String config, boolean metricsEnabled, int metricsPort) throws Exception {
+        ConfigurationBuilderHolder holder = parseConfiguration(config);
+        toggleMetrics(holder, metricsEnabled);
+        mgr = new DefaultCacheManager(holder, true);
         mgr.addListener(this);
+        if (metricsEnabled) {
+            startMetricsServer(metricsPort);
+        }
     }
 
     public void destroy() {
         mgr.stop();
+        if (metricsServerThread != null) {
+            metricsServerThread.interrupt();
+            try {
+                metricsServerThread.join();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     public Cache<K,V> create(String cache_name, String ignored) {
         org.infinispan.Cache<K,V> cache=mgr.getCache(cache_name);
         // for a put(), we don't need the previous value
         return new InfinispanCache<>(cache);
+    }
+
+    @Override
+    public LongConsumer metricForOperation(String operation) {
+        var registry = metricsRegistry();
+        if (!(registry instanceof MetricsRegistryImpl)) {
+            return value -> {};
+        }
+        Timer timer = Timer.builder("requests")
+                .description("The benchmark requests")
+                .publishPercentileHistogram(true)
+                .tags("operation", operation, Constants.NODE_TAG_NAME, mgr.getAddress().toString())
+                .register(((MetricsRegistryImpl) registry).registry());
+        return value -> timer.record(value, TimeUnit.NANOSECONDS);
     }
 
     @ViewChanged
@@ -46,5 +94,52 @@ public class InfinispanCacheFactory<K,V> implements CacheFactory<K,V> {
             sb.append(" [").append(Util.printListWithDelimiter(evt.getNewMembers(), ", ", Util.MAX_LIST_PRINT_SIZE)).append("]");
         }
         System.out.println("** view: " + sb);
+    }
+
+    private void startMetricsServer(int metricsPort) {
+        var registry = metricsRegistry();
+        if (!registry.supportScrape()) {
+            return;
+        }
+        // ISPN 15 and ISPN 16 use an incompatible version of prometheus metrics.
+        try {
+            System.out.println("Starting Prometheus server in port " + metricsPort);
+            HttpServer server = HttpServer.create(new InetSocketAddress(metricsPort), 0);
+            server.createContext("/metrics", httpExchange -> {
+                // a bit hacky but this should work for both ISPN 15 and ISPN 16
+                String response = registry.scrape("text/plain; version=0.0.4; charset=utf-8");
+                httpExchange.getResponseHeaders().add("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+                httpExchange.sendResponseHeaders(200, response.getBytes().length);
+                try (OutputStream os = httpExchange.getResponseBody()) {
+                    os.write(response.getBytes());
+                }
+            });
+
+            metricsServerThread = ThreadCreator.createThread(server::start, "prometheus", true, true);
+            metricsServerThread.start();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private MetricsRegistry metricsRegistry() {
+        return GlobalComponentRegistry.componentOf(mgr, MetricsRegistry.class);
+    }
+
+    private static ConfigurationBuilderHolder parseConfiguration(String config) throws IOException {
+        try (InputStream is = FileLookupFactory.newInstance().lookupFileStrict(config, Thread.currentThread().getContextClassLoader())) {
+            return new ParserRegistry().parse(is, ConfigurationResourceResolvers.DEFAULT, MediaType.APPLICATION_XML);
+        }
+    }
+
+    private static void toggleMetrics(ConfigurationBuilderHolder holder, boolean enabled) {
+        holder.getGlobalConfigurationBuilder()
+                .cacheContainer().statistics(enabled)
+                .metrics().gauges(enabled).histograms(false).namesAsTags(true);
+        holder.getNamedConfigurationBuilders()
+                .values()
+                .stream()
+                .map(ConfigurationBuilder::statistics)
+                .forEach(b -> b.enabled(enabled));
     }
 }

--- a/src/main/java/org/cache/impl/LocalCacheFactory.java
+++ b/src/main/java/org/cache/impl/LocalCacheFactory.java
@@ -9,7 +9,7 @@ import org.cache.CacheFactory;
  */
 public class LocalCacheFactory<K,V> implements CacheFactory<K,V> {
     @Override
-    public void init(String config) throws Exception {
+    public void init(String config, boolean metricsEnabled, int metricsPort) throws Exception {
         ;
     }
 

--- a/src/main/java/org/cache/impl/RaftCacheFactory.java
+++ b/src/main/java/org/cache/impl/RaftCacheFactory.java
@@ -9,7 +9,7 @@ public class RaftCacheFactory<K, V> implements CacheFactory<K, V> {
   private JChannel channel;
 
   @Override
-  public void init(String config) throws Exception {
+  public void init(String config, boolean metricsEnabled, int metricsPort) throws Exception {
     channel = new JChannel(config);
 
     channel.connect("raft-cluster");

--- a/src/main/java/org/cache/impl/tri/TriCacheFactory.java
+++ b/src/main/java/org/cache/impl/tri/TriCacheFactory.java
@@ -12,7 +12,7 @@ public class TriCacheFactory<K,V> implements CacheFactory<K,V> {
     protected String        config;
     protected TriCache<K,V> cache;
 
-    public void init(String config) throws Exception {
+    public void init(String config, boolean metricsEnabled, int metricsPort) throws Exception {
         this.config=config;
     }
 

--- a/src/main/java/org/jmh/Benchmark.java
+++ b/src/main/java/org/jmh/Benchmark.java
@@ -73,7 +73,7 @@ public class Benchmark {
         String cache_factory_class=tmp[0];
         String cfg=tmp[1];
         cache_factory=createFactory(cache_factory_class);
-        cache_factory.init(cfg);
+        cache_factory.init(cfg, false, 8080);
         cache=cache_factory.create(cache_name, null);
         System.out.printf("\n-- created cache from factory %s\n", cache_factory.getClass().getSimpleName());
         if(cache.isEmpty()) {

--- a/src/main/java/org/perf/Demo.java
+++ b/src/main/java/org/perf/Demo.java
@@ -2,21 +2,45 @@ package org.perf;
 
 import org.cache.Cache;
 import org.cache.CacheFactory;
-import org.cache.impl.*;
+import org.cache.impl.DummyCacheFactory;
+import org.cache.impl.HazelcastCacheFactory;
+import org.cache.impl.InfinispanCache;
+import org.cache.impl.InfinispanCacheFactory;
+import org.cache.impl.LocalCacheFactory;
+import org.cache.impl.RaftCacheFactory;
 import org.cache.impl.tri.TriCacheFactory;
 import org.infinispan.commons.jdkspecific.ThreadCreator;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
-import org.jgroups.*;
+import org.jgroups.Address;
+import org.jgroups.Event;
+import org.jgroups.Global;
+import org.jgroups.JChannel;
+import org.jgroups.Message;
+import org.jgroups.Receiver;
+import org.jgroups.Version;
+import org.jgroups.View;
 import org.jgroups.annotations.Property;
 import org.jgroups.protocols.TP;
+import org.jgroups.util.Bits;
+import org.jgroups.util.ByteArrayDataInputStream;
+import org.jgroups.util.ByteArrayDataOutputStream;
+import org.jgroups.util.DefaultThreadFactory;
+import org.jgroups.util.Promise;
+import org.jgroups.util.Streamable;
+import org.jgroups.util.ThreadFactory;
 import org.jgroups.util.UUID;
-import org.jgroups.util.*;
+import org.jgroups.util.Util;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutorService;
 
@@ -71,7 +95,7 @@ public class Demo implements Receiver {
 
         Class<CacheFactory<Integer,byte[]>> clazz=(Class<CacheFactory<Integer,byte[]>>)Util.loadClass(factory, (Class<?>)null);
         cache_factory=clazz.getDeclaredConstructor().newInstance();
-        cache_factory.init(cfg);
+        cache_factory.init(cfg, false, 8080);
         cache=cache_factory.create(cache_name, name);
 
         control_channel=new JChannel(control_cfg);

--- a/src/main/java/org/perf/IspnTest.java
+++ b/src/main/java/org/perf/IspnTest.java
@@ -17,7 +17,7 @@ public class IspnTest {
 
     protected void start() throws Exception {
         cache_factory=new InfinispanCacheFactory();
-        cache_factory.init(config);
+        cache_factory.init(config, false, 8080);
         cache=cache_factory.create("perf-cache", "X");
 
         for(int i=0; i < NUM; i++)


### PR DESCRIPTION
Opens a port and exposes the Prometheus metrics in `text/plain` format. 

### Limitations

* JGroups metrics are not available with Infinispan 15 + JGroups 5.5 combination due to different APIs (`Expecting non-static method 'long org.jgroups.protocols.TP.getNumberOfThreadDumps()'`)
* The Prometheus configuration is static and must be updated with the IPs and ports of the benchmark instances.
* A simple dashboard is installed by default, as shown below. It dynamically adapts to the number of instances by adding more rows. 

<img width="1920" height="963" alt="Screenshot 2025-08-22 at 15-31-49 Benchmark - Dashboards - Grafana" src="https://github.com/user-attachments/assets/2105f9b9-6ec8-4664-88e4-e8769ebb9aa1" />
